### PR TITLE
Allow back porting to rails 4

### DIFF
--- a/authtrail.gemspec
+++ b/authtrail.gemspec
@@ -19,11 +19,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 5"
-  spec.add_dependency "activerecord", ">= 5"
   spec.add_dependency "warden"
   spec.add_dependency "geocoder"
 
+  spec.add_development_dependency "railties", ">= 5"
+  spec.add_development_dependency "activerecord", ">= 5"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
I have remove the explicit Rails 5 functionality while trying to minimise the changes.

This means that anyone who wants to would be able to use this gem in a rails 4 application (assuming the define ApplicationRecord and ApplicationJob in a sensible fashion.

I am happy to talk through these changes or look at other approaches to get this gem working with rails 4.

Thanks

David