### PR TITLE
Look up default strategy from Warden env on auth fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ rake db:migrate
 A `LoginActivity` record is created every time a user tries to login. You can then use this information to detect suspicious behavior. Data includes:
 
 - `scope` - Devise scope
-- `strategy` - `database_authenticatable` for password logins, `rememberable` for remember me cookie, or the name of the OmniAuth strategy
+- `strategy` - Winning Devise strategy used for authentication
 - `identity` - email address
 - `success` - whether the login succeeded
 - `failure_reason` - if the login failed

--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -28,8 +28,12 @@ module AuthTrail
             request = ActionDispatch::Request.new(env)
             identity = request.params[opts[:scope]] && request.params[opts[:scope]][:email] rescue nil
 
+            warden_config = env['warden'].config
+            default_scope = warden_config[:default_scope]
+            default_strategy = warden_config[:default_strategies][default_scope][0]
+
             AuthTrail.track(
-              strategy: "database_authenticatable",
+              strategy: default_strategy,
               scope: opts[:scope].to_s,
               identity: identity,
               success: false,

--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -26,11 +26,13 @@ module AuthTrail
         AuthTrail.safely do
           if opts[:message]
             request = ActionDispatch::Request.new(env)
-            identity = request.params[opts[:scope]] && request.params[opts[:scope]][:email] rescue nil
+            scope = opts[:scope]
+            identity = request.params[scope] && request.params[scope][:email] rescue nil
 
             warden_config = env['warden'].config
-            default_scope = warden_config[:default_scope]
-            default_strategy = warden_config[:default_strategies][default_scope][0]
+            default_strategies = warden_config[:default_strategies][scope]
+            default_strategies.delete(:rememberable)
+            default_strategy = default_strategies.first.to_s
 
             AuthTrail.track(
               strategy: default_strategy,

--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -29,13 +29,12 @@ module AuthTrail
             scope = opts[:scope]
             identity = request.params[scope] && request.params[scope][:email] rescue nil
 
-            warden_config = env['warden'].config
-            default_strategies = warden_config[:default_strategies][scope]
-            default_strategies.delete(:rememberable)
-            default_strategy = default_strategies.first.to_s
+            winning_strategy = env["warden"].winning_strategy
+            winning_strategy_class_name = winning_strategy.class.name.split("::").last
+            strategy = ActiveSupport::Inflector.underscore(winning_strategy_class_name)
 
             AuthTrail.track(
-              strategy: default_strategy,
+              strategy: strategy,
               scope: opts[:scope].to_s,
               identity: identity,
               success: false,


### PR DESCRIPTION
# What does this do? 

When a user attempts to login and fails, this sets the `:strategy` attribute of the LoginActivity record based on the default strategies being used instead of always setting to "database_authenticatable". 

See #11 for more background.

# How does it work? 

This relies on data in the `env` argument passed down by the `before_failure` Warden hook. Here's an example of the shape of `env['warden'].config` in the context of an education-related web app: 

```
# env['warden'].config:

{:default_scope=>:educator, 
  :scope_defaults=>{}, 
  :default_strategies=>{:educator=>[:ldap_authenticatable_tiny, :rememberable]}, 
  :intercept_401=>false, 
  :failure_app=>#<Devise::Delegator:0x007fd464db0840>}
```

# Edge cases

+ If the array of default strategies is empty for some reason, strategy will be set to `nil`, which seems right. 
+ @ankane, are there specific Warden-related edge cases you recommend testing against? 