### PR TITLE
Add note about using polymorphic association to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ A `LoginActivity` record is created every time a user tries to login. You can th
 - `city`, `region`, and `country` - from IP
 - `created_at` - time of event
 
+Associate `LoginActivity` with your user model:
+
+```
+class Manager < ApplicationRecord
+  has_many :login_activities, as: :user
+end
+```
+
+The `LoginActivity` model uses a [polymorphic](http://guides.rubyonrails.org/association_basics.html#polymorphic-associations) association out of the box, so login activities can belong to different models (User, Admin, Manager, etc).
+
 ## Features
 
 Exclude certain attempts from tracking - useful if you run acceptance tests

--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ A `LoginActivity` record is created every time a user tries to login. You can th
 - `city`, `region`, and `country` - from IP
 - `created_at` - time of event
 
+## Features
+
+Exclude certain attempts from tracking - useful if you run acceptance tests:
+
+```ruby
+AuthTrail.exclude_method = proc do |info|
+  info[:identity] == "capybara@example.org"
+end
+```
+
+Write data somewhere other than the `login_activities` table:
+
+```ruby
+AuthTrail.track_method = proc do |info|
+  # code
+end
+```
+
 Associate `LoginActivity` with your user model:
 
 ```
@@ -44,24 +62,6 @@ end
 ```
 
 The `LoginActivity` model uses a [polymorphic](http://guides.rubyonrails.org/association_basics.html#polymorphic-associations) association out of the box, so login activities can belong to different models (User, Admin, Manager, etc).
-
-## Features
-
-Exclude certain attempts from tracking - useful if you run acceptance tests
-
-```ruby
-AuthTrail.exclude_method = proc do |info|
-  info[:identity] == "capybara@example.org"
-end
-```
-
-Write data somewhere other than the `login_activities` table.
-
-```ruby
-AuthTrail.track_method = proc do |info|
-  # code
-end
-```
 
 ## Geocoding
 


### PR DESCRIPTION
# Notes 

When I was first exploring integrating authtrail, I was confused about how to reconcile fields named `user_id` and `user_type` with my application's `Educator` model and `educator_id` field. Took me a bit of poking around to realize that this was what the polymorphic setting on `LoginActivity` is for. Adding a note to possibly save other users a few minutes by explaining this in the README. 😄 