### PR TITLE
Track user on failed login when possible

### DIFF
--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -21,13 +21,18 @@ module AuthTrail
         AuthTrail.safely do
           if opts[:message]
             request = ActionDispatch::Request.new(env)
+            identity = detect_identity(request, opts, nil)
+            scope = opts[:scope].to_s
+            scope_class = scope.capitalize.constantize
+            user = identity ? scope_class.find_by_email(identity) : nil
 
             AuthTrail.track(
               strategy: detect_strategy(env["warden"]),
-              scope: opts[:scope].to_s,
-              identity: detect_identity(request, opts, nil),
+              scope: scope,
+              identity: identity,
               success: false,
               request: request,
+              user: user,
               failure_reason: opts[:message].to_s
             )
           end


### PR DESCRIPTION
# Note

Experimenting with authtrail, I noticed that `user_id` and `user_type` are only set for a `LoginActivity` when the login attempt was successful. 

This sets `user_id` and `user_type` on a failed login attempt if the email identifier matches the email of an existing user record in the database.

If the email identifier for the login attempt doesn't match any records in the database, `user_id` and `user_type` are both left `nil`.