### PR TITLE
Fix dependency on ApplicationJob

### DIFF
--- a/app/jobs/auth_trail/geocode_job.rb
+++ b/app/jobs/auth_trail/geocode_job.rb
@@ -1,5 +1,5 @@
 module AuthTrail
-  class GeocodeJob < Rails::VERSION::MAJOR >= 5 ? ApplicationJob : ActiveJob::Base
+  class GeocodeJob < defined?(ApplicationJob) ? ApplicationJob : ActiveJob::Base
     def perform(login_activity)
       result =
         begin

--- a/app/jobs/auth_trail/geocode_job.rb
+++ b/app/jobs/auth_trail/geocode_job.rb
@@ -1,5 +1,5 @@
 module AuthTrail
-  class GeocodeJob < defined?(ApplicationJob) ? ApplicationJob : ActiveJob::Base
+  class GeocodeJob < (ApplicationJob rescue ActiveJob::Base)
     def perform(login_activity)
       result =
         begin

--- a/test/authtrail_test.rb
+++ b/test/authtrail_test.rb
@@ -4,4 +4,32 @@ class AuthTrailTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::AuthTrail::VERSION
   end
+
+  def test_that_geocode_job_inherits_from_active_job_base_if_application_job_not_defined
+    fork {
+      define_active_job_base
+      require_relative "../app/jobs/auth_trail/geocode_job.rb"
+      assert(AuthTrail::GeocodeJob.superclass == ActiveJob::Base)
+    }
+  end
+
+  def test_that_geocode_job_inherits_from_application_job_if_application_job_defined
+    fork {
+      define_active_job_base
+      define_application_job
+      require_relative "../app/jobs/auth_trail/geocode_job.rb"
+      assert(AuthTrail::GeocodeJob.superclass == ApplicationJob)
+    }
+  end
+
+  private
+
+    def define_active_job_base
+      Object.const_set('ActiveJob', Module.new { const_set('Base', Class.new) })
+    end
+
+    def define_application_job
+      Object.const_set('ApplicationJob', Class.new)
+    end
+
 end

--- a/test/authtrail_test.rb
+++ b/test/authtrail_test.rb
@@ -8,7 +8,7 @@ class AuthTrailTest < Minitest::Test
   def test_that_geocode_job_inherits_from_active_job_base_if_application_job_not_defined
     fork {
       define_active_job_base
-      require_relative "../app/jobs/auth_trail/geocode_job.rb"
+      require_relative "../app/jobs/auth_trail/geocode_job"
       assert(AuthTrail::GeocodeJob.superclass == ActiveJob::Base)
     }
   end
@@ -17,7 +17,7 @@ class AuthTrailTest < Minitest::Test
     fork {
       define_active_job_base
       define_application_job
-      require_relative "../app/jobs/auth_trail/geocode_job.rb"
+      require_relative "../app/jobs/auth_trail/geocode_job"
       assert(AuthTrail::GeocodeJob.superclass == ApplicationJob)
     }
   end


### PR DESCRIPTION
Make the dependency on `ApplicationJob` conditional. If it is defined, use it. If not, use `ActiveJob::Base` instead. This protects against "uninitialized constant" exceptions in Rails 5+ apps that do not define `ApplicationJob`.

Background:
[PR #17](https://github.com/ankane/authtrail/pull/17) introduced a dependency on `ApplicationJob` for Rails 5+ apps.  (`Rails::VERSION::MAJOR >= 5 ? ApplicationJob : ActiveJob::Base`)  However, `ApplicationJob` doesn't exist for many Rails 5 apps.  It may have never existed if the app was upgraded from Rails 4, it may have been deleted if it wasn't necessary, etc.  For those apps, AuthTrail's dependency on `ApplicationJob` will trigger the exception "uninitialized constant AuthTrail::ApplicationJob".

This problem was reported in [Issue #4](https://github.com/ankane/authtrail/issues/4).  The reporter closed the issue after adding `ApplicationJob` to her app to make the exception go away, but I think the underlying problem is still valid.  This PR solves that problem.

P.S. Thanks for creating AuthTrail!  It was exactly what I needed for a high-security production application, and has been working nicely.