### PR TITLE
Store latitude/longitude coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A `LoginActivity` record is created every time a user tries to login. You can th
 - `ip` - IP address
 - `user_agent` and `referrer` - from browser
 - `city`, `region`, and `country` - from IP
+- `latitude` and `longitude` - from IP (see "Coordinates" below)
 - `created_at` - time of event
 
 ## Features
@@ -87,6 +88,13 @@ Set job queue for geocoding
 
 ```ruby
 AuthTrail::GeocodeJob.queue_as :low
+```
+
+### Coordinates
+
+If you want to store latitude/longitude coordinates, but you installed version 0.1.3 or before, you need to add coordinates columns to your database. Generate another migration:
+```ruby
+bundle exec rails g migration AddCoordinatesToLoginActivities latitude:float longitude:float
 ```
 
 ### Geocoding Performance

--- a/app/jobs/auth_trail/geocode_job.rb
+++ b/app/jobs/auth_trail/geocode_job.rb
@@ -10,12 +10,31 @@ module AuthTrail
         end
 
       if result
-        login_activity.update!(
+        with_coordinates = model_supports_coordinates?(login_activity)
+        attributes = attributes_for_result(result, with_coordinates)
+        login_activity.update!(attributes)
+      end
+    end
+
+    private
+
+      def attributes_for_result(result, with_coordinates)
+        attributes = {
           city: result.try(:city).presence,
           region: result.try(:state).presence,
           country: result.try(:country).presence
-        )
+        }
+        if with_coordinates
+          attributes[:latitude] = result.try(:latitude).presence
+          attributes[:longitude] = result.try(:longitude).presence
+        end
+        attributes
       end
-    end
+
+      def model_supports_coordinates?(login_activity)
+        column_names = login_activity.class.column_names
+        column_names.include?('latitude') && column_names.include?('longitude')
+      end
+
   end
 end

--- a/app/jobs/auth_trail/geocode_job.rb
+++ b/app/jobs/auth_trail/geocode_job.rb
@@ -10,24 +10,16 @@ module AuthTrail
         end
 
       if result
-        geocode_to_login_activity_mapping.each do |geocode_attr, login_activity_attr|
-          next unless login_activity.respond_to?("#{login_activity_attr}=")
-          login_activity.send("#{login_activity_attr}=", result.try(geocode_attr).presence)
+        login_activity.assign_attributes(
+          city: result.try(:city).presence,
+          region: result.try(:state).presence,
+          country: result.try(:country).presence
+        )
+        %w(latitude longitude).each do |attribute|
+          login_activity.try("#{attribute}=", result.try(attribute).presence)
         end
         login_activity.save!
       end
-    end
-
-    private
-
-    def geocode_to_login_activity_mapping
-      {
-        city: :city,
-        country: :country,
-        latitude: :latitude,
-        longitude: :longitude,
-        state: :region,
-      }
     end
   end
 end

--- a/app/jobs/auth_trail/geocode_job.rb
+++ b/app/jobs/auth_trail/geocode_job.rb
@@ -10,12 +10,24 @@ module AuthTrail
         end
 
       if result
-        %w(city country latitude longitude region).each do |attribute|
-          next unless login_activity.respond_to?("#{attribute}=")
-          login_activity.send("#{attribute}=", result.try(attribute).presence)
+        geocode_to_login_activity_mapping.each do |geocode_attr, login_activity_attr|
+          next unless login_activity.respond_to?("#{login_activity_attr}=")
+          login_activity.send("#{login_activity_attr}=", result.try(geocode_attr).presence)
         end
         login_activity.save!
       end
+    end
+
+    private
+
+    def geocode_to_login_activity_mapping
+      {
+        city: :city,
+        country: :country,
+        latitude: :latitude,
+        longitude: :longitude,
+        state: :region,
+      }
     end
   end
 end

--- a/lib/generators/authtrail/templates/login_activities_migration.rb.tt
+++ b/lib/generators/authtrail/templates/login_activities_migration.rb.tt
@@ -14,6 +14,8 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.string :city
       t.string :region
       t.string :country
+      t.float :latitude
+      t.float :longitude
       t.datetime :created_at
     end
 


### PR DESCRIPTION
Geocoder generally returns coordinates for IP address requests. This
modifies the geocoding job to store those values. Also updates the
migration template and adds upgrade instructions to the documentation.

Currently authtrail stores geolocation data for city/region/country. That
is helpful when looking at a specific login, but not as helpful for
comparing logins. With coordinates you can do rough distance
calculations using `Geocoder::Calculations.distance_between`. This
can be helpful in identifying fraud patterns, for example.