### PR TITLE
Allow custom login activity attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,25 @@ AuthTrail.exclude_method = lambda do |info|
 end
 ```
 
+Define custom attributes to be persisted 
+
+```ruby
+AuthTrail.login_activity_attributes_method = lambda do |strategy, scope, identity, success, request, user, failure_reason|
+  {
+    strategy:       strategy,
+    scope:          scope,
+    identity:       identity,
+    success:        success,
+    failure_reason: failure_reason,
+    user:           user,
+    ip:             request.remote_ip,
+    user_agent:     request.user_agent,
+    referrer:       request.referrer,
+    my_custom_value:'some value'
+  }
+end
+``` 
+
 Write data somewhere other than the `login_activities` table
 
 ```ruby

--- a/lib/authtrail.rb
+++ b/lib/authtrail.rb
@@ -9,7 +9,7 @@ require "auth_trail/version"
 
 module AuthTrail
   class << self
-    attr_accessor :exclude_method, :geocode, :track_method, :identity_method
+    attr_accessor :exclude_method, :geocode, :track_method, :identity_method, :login_activity_attributes_method
   end
   self.geocode = true
   self.identity_method = lambda do |request, opts, user|
@@ -20,32 +20,35 @@ module AuthTrail
       request.params[scope] && request.params[scope][:email] rescue nil
     end
   end
+  self.login_activity_attributes_method = lambda do |strategy, scope, identity, success, request, user, failure_reason|
+    {
+        strategy:       strategy,
+        scope:          scope,
+        identity:       identity,
+        success:        success,
+        failure_reason: failure_reason,
+        user:           user,
+        ip:             request.remote_ip,
+        user_agent:     request.user_agent,
+        referrer:       request.referrer
+    }
+  end
 
   def self.track(strategy:, scope:, identity:, success:, request:, user: nil, failure_reason: nil)
-    info = {
-      strategy: strategy,
-      scope: scope,
-      identity: identity,
-      success: success,
-      failure_reason: failure_reason,
-      user: user,
-      ip: request.remote_ip,
-      user_agent: request.user_agent,
-      referrer: request.referrer
-    }
+    login_activity_attributes = AuthTrail.login_activity_attributes_method.call(strategy, scope, identity, success, request, user, failure_reason)
 
     if request.params[:controller]
-      info[:context] = "#{request.params[:controller]}##{request.params[:action]}"
+      login_activity_attributes[:context] = "#{request.params[:controller]}##{request.params[:action]}"
     end
 
     # if exclude_method throws an exception, default to not excluding
-    exclude = AuthTrail.exclude_method && AuthTrail.safely(default: false) { AuthTrail.exclude_method.call(info) }
+    exclude = AuthTrail.exclude_method && AuthTrail.safely(default: false) { AuthTrail.exclude_method.call(login_activity_attributes) }
 
     unless exclude
       if AuthTrail.track_method
-        AuthTrail.track_method.call(info)
+        AuthTrail.track_method.call(login_activity_attributes)
       else
-        login_activity = LoginActivity.create!(info)
+        login_activity = LoginActivity.create!(login_activity_attributes)
         AuthTrail::GeocodeJob.perform_later(login_activity) if AuthTrail.geocode
       end
     end


### PR DESCRIPTION
We had a use case wherby we needed to extract some additional information from the request.

At first we looked to implement this using a custom `AuthTrail.track_method` however this only provides a fixed set of attributes and does not provide access to the `request` object.

I did consider adding the `request` object to the options provided to a custom `AuthTrail.track_method` but wanted to maintain existing interfaces as much as possible.

I have therefore allowed for a custom proc to be defined that can be used to provide additional attributes as may be neccersary. If no custom proc is supplied then the current behaviour remains the same.