### PR TITLE
[Idea/Proposal] when a signin fails ... still try to associate the user

### DIFF
--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -20,14 +20,17 @@ module AuthTrail
       def before_failure(env, opts)
         AuthTrail.safely do
           if opts[:message]
-            request = ActionDispatch::Request.new(env)
+            request  = ActionDispatch::Request.new(env)
+            identity = AuthTrail.identity_method.call(request, opts, nil)
+            user     = AuthTrail.identity_fetch_method.call(identity)
 
             AuthTrail.track(
               strategy: detect_strategy(env["warden"]),
               scope: opts[:scope].to_s,
-              identity: AuthTrail.identity_method.call(request, opts, nil),
+              identity: identity,
               success: false,
               request: request,
+              user: user,
               failure_reason: opts[:message].to_s
             )
           end

--- a/lib/authtrail.rb
+++ b/lib/authtrail.rb
@@ -9,7 +9,7 @@ require "auth_trail/version"
 
 module AuthTrail
   class << self
-    attr_accessor :exclude_method, :geocode, :track_method, :identity_method
+    attr_accessor :exclude_method, :geocode, :track_method, :identity_method, :identity_fetch_method
   end
   self.geocode = true
   self.identity_method = lambda do |request, opts, user|
@@ -19,6 +19,9 @@ module AuthTrail
       scope = opts[:scope]
       request.params[scope] && request.params[scope][:email] rescue nil
     end
+  end
+
+  self.identity_fetch_method = lambda do |identity|
   end
 
   def self.track(strategy:, scope:, identity:, success:, request:, user: nil, failure_reason: nil)

--- a/test/authtrail_test.rb
+++ b/test/authtrail_test.rb
@@ -8,7 +8,7 @@ class AuthTrailTest < ActionDispatch::IntegrationTest
 
   def test_success
     user = User.create!(email: "test@example.org")
-    post users_sign_in_url, params: {user: {email: "test@example.org"}}
+    post users_sign_in_url, params: {user: {email: "test@example.org", password: 'sEcReT'}}
     assert_response :success
 
     assert_equal 1, LoginActivity.count
@@ -34,6 +34,27 @@ class AuthTrailTest < ActionDispatch::IntegrationTest
     refute login_activity.success
     assert_equal "Could not sign in", login_activity.failure_reason
     assert_nil login_activity.user
+    assert_equal "users#sign_in", login_activity.context
+  end
+
+  def test_failure_with_recoverable_user
+    user = User.create!(email: "test@example.org")
+
+    AuthTrail.identity_fetch_method = ->(identity) do
+      User.find_by(email: identity)
+    end
+
+    post users_sign_in_url, params: {user: {email: "test@example.org"}}
+    assert_response :unauthorized
+
+    assert_equal 1, LoginActivity.count
+    login_activity = LoginActivity.last
+    assert_equal "user", login_activity.scope
+    assert_equal "password_strategy", login_activity.strategy
+    assert_equal "test@example.org", login_activity.identity
+    refute login_activity.success
+    assert_equal "Could not sign in", login_activity.failure_reason
+    assert_equal user, login_activity.user
     assert_equal "users#sign_in", login_activity.context
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,13 @@ require "warden"
 class PasswordStrategy < Warden::Strategies::Base
   def authenticate!
     u = User.find_by(email: params.dig("user", "email"))
-    u.nil? ? fail!("Could not sign in") : success!(u)
+
+    if u.nil? || params.dig('user', 'password') != 'sEcReT'
+      fail!("Could not sign in")
+    else
+      success!(u)
+    end
+
   end
 end
 


### PR DESCRIPTION
use:

```ruby
    AuthTrail.identity_fetch_method = ->(identity) do
      User.find_by(email: identity)
    end
```

to find the user that tried to login but failed based on the provided `identity`
to keep the association intact and be able to
show those events to the end-user