### PR TITLE
Separate method for fetching the ip from a request

### DIFF
--- a/lib/auth_trail/version.rb
+++ b/lib/auth_trail/version.rb
@@ -1,3 +1,3 @@
 module AuthTrail
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/lib/authtrail.rb
+++ b/lib/authtrail.rb
@@ -21,6 +21,10 @@ module AuthTrail
     end
   end
 
+  def self.ip_for(request)
+    request.remote_ip
+  end
+
   def self.track(strategy:, scope:, identity:, success:, request:, user: nil, failure_reason: nil)
     info = {
       strategy: strategy,
@@ -29,7 +33,7 @@ module AuthTrail
       success: success,
       failure_reason: failure_reason,
       user: user,
-      ip: request.remote_ip,
+      ip: self.ip_for(request),
       user_agent: request.user_agent,
       referrer: request.referrer
     }


### PR DESCRIPTION
For whatever reason Azure Web App conveniently switches `request.ip` and `request.remote_ip`. The net is `request.ip` is the actual ip and `request.remote_ip` is the internal ip. Super helpful.

I'm just looking for an easy entry point to monkey patch what ip address is being used for the LoginActivity entry. My thinking with this change is that I can simply override the `AuthTrail.ip_for(request)` method with one that returns `request.ip`.

Open to other suggestions, but this seemed to do the trick without being too ugly :-) Had the same issue with Ahoy but could easily override the `ip` method.