### PR TITLE
doc(readme): updating migration file when encrypting

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,24 @@ class LoginActivity < ApplicationRecord
 end
 ```
 
+You will also need to update the generated migration file for each field you encrypt and use blind index on.
+
+Remove the lines:
+
+```ruby
+t.string :identity
+t.string :ip
+```
+
+Replace them with:
+
+```ruby
+t.string :identity_ciphertext
+t.string :identity_bidx, index: true
+t.string :ip_ciphertext
+t.string :ip_bidx, index: true
+```
+
 ## Other Notes
 
 We recommend using this in addition to Devise’s `Lockable` module and [Rack::Attack](https://github.com/kickstarter/rack-attack).


### PR DESCRIPTION
When using `encrypts` and `blind_index`, the generated migration file needs to be changed. The generated `identity` and `ip` columns need to be replaced with `identity_ciphertext` and `identity_bidx`, for example.