### PR TITLE
feat: Add UUID support for user references

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ rails generate authtrail:install --encryption=none
 rails db:migrate
 ```
 
+If your application uses UUID for user IDs, add the `--uuid` option:
+
+```sh
+rails generate authtrail:install --encryption=[lockbox|activerecord|none] --uuid
+rails db:migrate
+```
+
 To enable geocoding, see the [Geocoding section](#geocoding).
 
 ## How It Works

--- a/lib/generators/authtrail/install_generator.rb
+++ b/lib/generators/authtrail/install_generator.rb
@@ -7,6 +7,7 @@ module Authtrail
       source_root File.join(__dir__, "templates")
 
       class_option :encryption, type: :string, required: true
+      class_option :uuid, type: :boolean, default: false, desc: 'Use UUID for user_id'
 
       def copy_migration
         encryption # ensure valid
@@ -77,6 +78,14 @@ module Authtrail
 
       def adapter
         ActiveRecord::Base.connection_db_config.adapter.to_s
+      end
+
+      def user_reference
+        if options[:uuid]
+          't.references :user, type: :uuid, polymorphic: true'
+        else
+          't.references :user, polymorphic: true'
+        end
       end
     end
   end

--- a/lib/generators/authtrail/templates/login_activities_migration.rb.tt
+++ b/lib/generators/authtrail/templates/login_activities_migration.rb.tt
@@ -6,7 +6,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       <%= identity_column %>
       t.boolean :success
       t.string :failure_reason
-      t.references :user, polymorphic: true
+      <%= user_reference %>
       t.string :context
       <%= ip_column %>
       t.text :user_agent

--- a/test/install_generator_test.rb
+++ b/test/install_generator_test.rb
@@ -28,4 +28,14 @@ class InstallGeneratorTest < Rails::Generators::TestCase
     assert_file "app/models/login_activity.rb", /LoginActivity < ApplicationRecord/
     assert_migration "db/migrate/create_login_activities.rb", /t.string :identity, index: true/
   end
+  
+  def test_uuid_option
+    run_generator ['--encryption=none', '--uuid']
+    assert_migration 'db/migrate/create_login_activities.rb', /t.references :user, type: :uuid, polymorphic: true/
+  end
+
+  def test_default_id_type
+    run_generator ['--encryption=none']
+    assert_migration 'db/migrate/create_login_activities.rb', /t.references :user, polymorphic: true/
+  end
 end


### PR DESCRIPTION
* Adds `--uuid` flag to install generator
* Creates `Authtrail::Generators::InstallGenerator#user_reference` helper method for migration template
* Creates tests for UUID and default ID type options
* Updates the README with instructions for the UUID argument