### PR TITLE
Support custom Warden strategies

### DIFF
--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -31,7 +31,7 @@ module AuthTrail
 
       def detect_strategy(auth)
         strategy = auth.env["omniauth.auth"]["provider"] if auth.env["omniauth.auth"]
-        strategy ||= Warden::Strategies._strategies.key(auth&.winning_strategy&.class)
+        strategy ||= Warden::Strategies._strategies.key(auth&.winning_strategy&.class)&.to_s
         strategy ||= auth.winning_strategy.class.name&.split("::")&.last&.underscore if auth.winning_strategy
         strategy ||= "database_authenticatable"
         strategy

--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -31,6 +31,7 @@ module AuthTrail
 
       def detect_strategy(auth)
         strategy = auth.env["omniauth.auth"]["provider"] if auth.env["omniauth.auth"]
+        strategy ||= Warden::Strategies._strategies.key(auth&.winning_strategy&.class)
         strategy ||= auth.winning_strategy.class.name.split("::").last.underscore if auth.winning_strategy
         strategy ||= "database_authenticatable"
         strategy

--- a/lib/auth_trail/manager.rb
+++ b/lib/auth_trail/manager.rb
@@ -32,7 +32,7 @@ module AuthTrail
       def detect_strategy(auth)
         strategy = auth.env["omniauth.auth"]["provider"] if auth.env["omniauth.auth"]
         strategy ||= Warden::Strategies._strategies.key(auth&.winning_strategy&.class)
-        strategy ||= auth.winning_strategy.class.name.split("::").last.underscore if auth.winning_strategy
+        strategy ||= auth.winning_strategy.class.name&.split("::")&.last&.underscore if auth.winning_strategy
         strategy ||= "database_authenticatable"
         strategy
       end

--- a/test/authtrail_test.rb
+++ b/test/authtrail_test.rb
@@ -129,13 +129,12 @@ class AuthTrailTest < ActionDispatch::IntegrationTest
     end
 
     Devise.warden_config[:default_strategies][:user].prepend(:custom_strategy)
-
     post user_session_url, params: {user: {email: "test@example.org", password: "secret"}}
-
-    Devise.warden_config[:default_strategies][:user].delete(:custom_strategy)
 
     assert_equal 1, LoginActivity.count
     login_activity = LoginActivity.last
     assert_equal "custom_strategy", login_activity.strategy
+  ensure
+    Devise.warden_config[:default_strategies][:user].delete(:custom_strategy)
   end
 end


### PR DESCRIPTION
The `warden` gem supports defining custom strategies as either a class or a block, via `Warden::Strategies.add(:strategy_name) { .... }`. All of Devise's built-in strategies are classes, but using custom strategies with block syntax causes `AuthTrail` to throw, as it's attempting to parse the class name of an anonymous class.

```ruby
NoMethodError: undefined method 'split' for nil
    lib/auth_trail/manager.rb:34:in 'AuthTrail::Manager.detect_strategy'
    lib/auth_trail/manager.rb:8:in 'AuthTrail::Manager.after_set_user'
    lib/authtrail.rb:72:in 'block in <top (required)>'
```

This PR adds support for custom strategies by looking up the class in Warden's internal strategy registry, and adds safe navigation to the class name parsing as a fallback, to prevent the `NoMethodError`.